### PR TITLE
add go module init skeleton

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/fumiyas/qrc
+
+go 1.22.2


### PR DESCRIPTION
Newer versions of go want to see a module name declared before `go get` can be run.